### PR TITLE
Update bin-wrapper to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jpeg-recompress"
   ],
   "dependencies": {
-    "bin-wrapper": "^3.0.0",
+    "bin-wrapper": "^4.0.1",
     "logalot": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**=== npm audit security report ===**

**Moderate**        Memory Exposure
**Package**         tunnel-agent
**Patched in**      >=0.6.0
**Dependency of**   imagemin-jpeg-recompress
**Path**            imagemin-jpeg-recompress > jpeg-recompress-bin > bin-wrapper > download > caw > tunnel-agent
